### PR TITLE
Fix: Auto-initialize extension to properly discover and load agent skillsFix: empty skill_list in tools.lua l.35.

### DIFF
--- a/lua/codecompanion/_extensions/agentskills/init.lua
+++ b/lua/codecompanion/_extensions/agentskills/init.lua
@@ -100,6 +100,21 @@ Extension.exports = {
   Skill = Skill,
   discover = discover_skills,
   get_skills = Extension.get_skills,
+  setup = Extension.setup,
 }
+
+-- Auto-initialize the extension when loaded by CodeCompanion
+local function try_auto_setup()
+  local ok, cc_config = pcall(require, "codecompanion.config")
+  if ok and cc_config.options and cc_config.options.extensions and cc_config.options.extensions.agentskills then
+    local ext_config = cc_config.options.extensions.agentskills
+    if ext_config.enabled ~= false and ext_config.opts then
+      Extension.setup(ext_config.opts)
+    end
+  end
+end
+
+-- Defer auto-setup to ensure CodeCompanion is fully loaded
+vim.schedule(try_auto_setup)
 
 return Extension


### PR DESCRIPTION
### Problem
The `skill_list` in `tools.lua` (line 35) was always empty, so the agent skills were unavailable. 
I used the lazyvim example as-is, so I was sure it wasn't a configuration issue.

### Root cause
The `Extension.setup(opts)` function was never being called during the extension loading. This caused the module-level `skills table to stay `nil`, causing `get_skills()` to return `nil`, which resulted in an empty skills list in the system prompt.

### Solution
1. Added `setup` to the `Extension.exports` table to make it explicitly available for manual initialization if needed

2. Added a `try_auto_setup()` function that:
   - attempts to read CodeCompanion's config using `pcall`
   - detects if the extension is configured
   - uses the `enabled` flag (only initializes if enabled is not explicitly false)
   - automatically calls `Extension.setup(opts)` with the user's configuration uses `vim.schedule()` to defer execution to ensure CodeCompanion is fully loaded

