### PR TITLE
feat: Add interpreter system for skill scripts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+*.py[cod]

--- a/demo-skill/SKILL.md
+++ b/demo-skill/SKILL.md
@@ -41,11 +41,20 @@ Load the skill file `references/welcome.md` and display its contents to the user
 
 ---
 
-### Step 4: Run Bash Version Check
+### Step 4: Run Bash Argument Demo
 
-**If `bash` is available**, run script `scripts/check_bash.sh` to check the installed Bash version.
+**If `bash` is available**, run script `scripts/check_bash.sh` with arguments.
 
-**If `bash` is NOT available**, note this and skip.
+Pass example arguments including:
+- a plain argument containing a whitespace like `first argument`
+- an argument containing `${SKILL_DIR}` such as `${SKILL_DIR}/references/welcome.md`
+
+Then verify that the script output contains:
+- the Bash version line
+- the first argument value
+- the resolved absolute path for the `${SKILL_DIR}`-based argument
+
+If the output does not match, report the mismatch in the final summary.
 
 ---
 
@@ -66,7 +75,7 @@ After completing all steps, output a summary table to the user:
 | 1 | Output execution plan | ✅ Done |
 | 2 | Load `references/welcome.md` | ✅ / ❌ |
 | 3 | Python demo (faker + relative imports) | ✅ / ❌ / ⏭️ Skipped |
-| 4 | Bash version check | ✅ / ❌ / ⏭️ Skipped |
+| 4 | Bash argument demo (args + `${SKILL_DIR}` placeholder validation) | ✅ / ❌ / ⏭️ Skipped |
 | 5 | Node.js version check | ✅ / ❌ / ⏭️ Skipped |
 
 Fill in the actual status for each step. Include any error messages for failed steps. End with a brief conclusion about whether the AgentSkills system is working correctly.

--- a/demo-skill/SKILL.md
+++ b/demo-skill/SKILL.md
@@ -1,0 +1,90 @@
+---
+name: demo-skill
+description: Use when user asks to run an AgentSkills demo, demonstrate AgentSkills capabilities, test skill file loading and script execution features, or verify the Agent Skills system is working correctly.
+---
+
+# Demo Skill
+
+This skill demonstrates the full capabilities of the **codecompanion-agentskills.nvim** plugin, including file loading, multi-language script execution, Python relative imports, and dependency management.
+
+## Instructions
+
+Follow these steps **in order**. Do not skip any step.
+
+---
+
+### Step 1: Output Execution Plan
+
+Before doing anything else, output an execution plan to the user in Markdown:
+
+```
+📋 Demo Skill Execution Plan
+─────────────────────────────────────────────
+1. YOUR FIRST ACTION
+2. ...
+─────────────────────────────────────────────
+```
+
+---
+
+### Step 2: Load Welcome File
+
+Load the skill file `references/welcome.md` and display its contents to the user.
+
+---
+
+### Step 3: Run Python Demo
+
+**If `python3` is available**, run script `scripts/run.py` with dependency `faker`.
+
+**If `python3` is NOT available**, note this in your summary and skip to the next step.
+
+---
+
+### Step 4: Run Bash Version Check
+
+**If `bash` is available**, run script `scripts/check_bash.sh` to check the installed Bash version.
+
+**If `bash` is NOT available**, note this and skip.
+
+---
+
+### Step 5: Run Node.js Version Check
+
+**If `node` is available**, run script `scripts/check_node.js` to check the installed Node.js version.
+
+**If `node` is NOT available**, note this and skip.
+
+---
+
+### Step 6: Summarize Results
+
+After completing all steps, output a summary table to the user:
+
+| Step | Description | Status |
+|------|-------------|--------|
+| 1 | Output execution plan | ✅ Done |
+| 2 | Load `references/welcome.md` | ✅ / ❌ |
+| 3 | Python demo (faker + relative imports) | ✅ / ❌ / ⏭️ Skipped |
+| 4 | Bash version check | ✅ / ❌ / ⏭️ Skipped |
+| 5 | Node.js version check | ✅ / ❌ / ⏭️ Skipped |
+
+Fill in the actual status for each step. Include any error messages for failed steps. End with a brief conclusion about whether the AgentSkills system is working correctly.
+
+---
+
+### Step 7: Output Available Agent Skills List
+
+Output the complete list of currently available Agent Skills in the following format:
+
+**Currently Available Agent Skills:**
+
+| # | Skill Name | Description |
+|---|------------|-------------|
+| 1 | skill-name-1 | Description 1 |
+| 2 | skill-name-2 | Description 2 |
+| ... | ... | ... |
+
+**Note:** 
+- If the total number of available Agent Skills exceeds 10, display only up to 10 skills that the user might be interested in, and add a note at the end indicating "And X more available skills not shown."
+- You can make reasonable assumptions about which skills might interest the user based on the context of this conversation.

--- a/demo-skill/demo_pkg/__init__.py
+++ b/demo-skill/demo_pkg/__init__.py
@@ -1,0 +1,10 @@
+"""
+demo_pkg - A demo Python package for the AgentSkills plugin.
+
+This __init__.py demonstrates relative imports by importing
+`generate_fake_data` from the sibling module `.helper`.
+"""
+
+from .helper import generate_fake_data
+
+__all__ = ["generate_fake_data"]

--- a/demo-skill/demo_pkg/helper.py
+++ b/demo-skill/demo_pkg/helper.py
@@ -1,0 +1,14 @@
+"""
+demo_pkg/helper.py
+
+Generates fake user data using the `faker` third-party library.
+This module is imported by __init__.py via a relative import:
+    from .helper import generate_fake_data
+"""
+
+from faker import Faker
+
+def generate_fake_data(count: int = 3) -> None:
+    fake = Faker()
+    for i in range(1, count + 1):
+        print(f"{i}. {fake.name()} | {fake.email()} | {fake.company()}")

--- a/demo-skill/references/welcome.md
+++ b/demo-skill/references/welcome.md
@@ -1,0 +1,9 @@
+# AgentSkills Demo
+
+This file was loaded via `load_skill_file` — demonstrating skill file access.
+
+**Three tools are available:**
+- `activate_skill` — load a skill's instructions
+- `load_skill_file` — read files from the skill's virtual directory
+- `run_skill_script` — execute scripts (Python/Bash/Node) bundled with the skill
+

--- a/demo-skill/scripts/check_bash.sh
+++ b/demo-skill/scripts/check_bash.sh
@@ -1,2 +1,6 @@
 #!/usr/bin/env bash
+
 echo "bash $BASH_VERSION"
+echo "arg_count=$#"
+printf 'arg1=%s\n' "${1-}"
+printf 'arg2=%s\n' "${2-}"

--- a/demo-skill/scripts/check_bash.sh
+++ b/demo-skill/scripts/check_bash.sh
@@ -1,0 +1,2 @@
+#!/usr/bin/env bash
+echo "bash $BASH_VERSION"

--- a/demo-skill/scripts/check_node.js
+++ b/demo-skill/scripts/check_node.js
@@ -1,0 +1,2 @@
+// scripts/check_node.js
+console.log(`node ${process.version} (${process.platform}/${process.arch})`);

--- a/demo-skill/scripts/run.py
+++ b/demo-skill/scripts/run.py
@@ -1,0 +1,16 @@
+"""
+scripts/run.py — Entry point for the Python demo.
+
+The AgentSkills Python interpreter sets PYTHONPATH to the skill root directory,
+so `demo_pkg` (located at the skill root) is importable as a top-level package.
+
+`demo_pkg/__init__.py` uses a relative import:
+    from .helper import generate_fake_data
+
+This script simply invokes that function.
+"""
+
+from demo_pkg import generate_fake_data
+
+if __name__ == "__main__":
+    generate_fake_data(count=3)

--- a/lua/codecompanion/_extensions/agentskills/init.lua
+++ b/lua/codecompanion/_extensions/agentskills/init.lua
@@ -8,6 +8,7 @@ local Extension = {}
 ---@field ignore_dirs? string[] List of directory names to ignore during skill discovery
 ---@field script_interpreters? table<string, table> Interpreter-specific configurations
 ---@field disable_demo_skill? boolean Disable the built-in demo-skill (default: false)
+---@field skill_opts? table<string, CodeCompanion.AgentSkills.SkillOpts> Per-skill options
 
 ---@type CodeCompanion.AgentSkills.Opts
 local current_opts = {
@@ -146,11 +147,6 @@ function Extension.setup(opts)
   }
   tools_config.run_skill_script = {
     callback = cc_compat.decorate_tool(tools_module.run_skill_script, version),
-    opts = {
-      allowed_in_yolo_mode = false,
-      require_approval_before = true,
-      require_cmd_approval = true,
-    },
     visible = false,
   }
   tools_config.groups.agent_skills = {

--- a/lua/codecompanion/_extensions/agentskills/init.lua
+++ b/lua/codecompanion/_extensions/agentskills/init.lua
@@ -5,6 +5,7 @@ local Extension = {}
 
 ---@class CodeCompanion.AgentSkills.Opts
 ---@field paths (string | { [1]: string, recursive: boolean })[] List of paths to search for skills
+---@field ignore_dirs? string[] List of directory names to ignore during skill discovery
 ---@field script_interpreters? table<string, table> Interpreter-specific configurations
 ---@field disable_demo_skill? boolean Disable the built-in demo-skill (default: false)
 
@@ -75,7 +76,7 @@ local function discover_skills()
           break
         end
         -- Skip hidden directories and commonly ignored directories
-        if name:sub(1, 1) ~= "." and not current_opts.ignore_dirs[name] then
+        if name:sub(1, 1) ~= "." and not vim.list_contains(current_opts.ignore_dirs, name) then
           local child = vim.fs.joinpath(dir, name)
           if is_dir_or_symlink_dir(child) then
             scan_skills(child, depth + 1, max_depth, result, visited)

--- a/lua/codecompanion/_extensions/agentskills/init.lua
+++ b/lua/codecompanion/_extensions/agentskills/init.lua
@@ -5,6 +5,8 @@ local Extension = {}
 
 ---@class CodeCompanion.AgentSkills.Opts
 ---@field paths (string | { [1]: string, recursive: boolean })[] List of paths to search for skills
+---@field script_interpreters? table<string, table> Interpreter-specific configurations
+---@field disable_demo_skill? boolean Disable the built-in demo-skill (default: false)
 
 ---@type CodeCompanion.AgentSkills.Opts
 local current_opts = {
@@ -86,7 +88,6 @@ local function discover_skills()
     scan_skills(path, 0, recursive and 99 or 1, skill_files, {})
     log:info("Found skill files: %s", skill_files)
 
-
     for _, skill_dir in ipairs(skill_files) do
       local ok, skill = pcall(Skill.load, skill_dir)
       if ok and skill and skill.name then
@@ -96,11 +97,29 @@ local function discover_skills()
       end
     end
   end
+
+  if not current_opts.disable_demo_skill then
+    local demo_skill_path = vim.fs.joinpath(
+      vim.fn.fnamemodify(debug.getinfo(1, "S").source:sub(2), ":p:h:h:h:h:h"),
+      "demo-skill"
+    )
+    local ok, demo_skill = pcall(Skill.load, demo_skill_path)
+    if ok and demo_skill then
+      skills[demo_skill:name()] = demo_skill
+      log:info("Loaded built-in demo-skill from %s", demo_skill_path)
+    else
+      log:warn("Failed to load built-in demo-skill from %s: %s", demo_skill_path, demo_skill)
+    end
+  end
 end
 
 ---@param opts CodeCompanion.AgentSkills.Opts
 function Extension.setup(opts)
   current_opts = vim.tbl_deep_extend("force", current_opts, opts or {})
+
+  require("codecompanion._extensions.agentskills.interpreter").setup(
+    current_opts.script_interpreters or {}
+  )
 
   -- Detect CodeCompanion version
   local ok, cc = pcall(require, "codecompanion")
@@ -149,6 +168,11 @@ end
 ---@return CodeCompanion.AgentSkills.Skill?
 function Extension.get_skill(name)
   return skills and skills[name]
+end
+
+---@return CodeCompanion.AgentSkills.Opts
+function Extension.get_opts()
+  return current_opts
 end
 
 Extension.exports = {

--- a/lua/codecompanion/_extensions/agentskills/interpreter/init.lua
+++ b/lua/codecompanion/_extensions/agentskills/interpreter/init.lua
@@ -1,0 +1,79 @@
+local log = require("codecompanion.utils.log")
+
+local M = {}
+
+---@class CodeCompanion.AgentSkills.InterpreterHandler
+---@field support_dependencies boolean
+---@field check_available fun(self: CodeCompanion.AgentSkills.InterpreterHandler): boolean
+---@field run fun(self: CodeCompanion.AgentSkills.InterpreterHandler, script_path: string, args: string[], skill: CodeCompanion.AgentSkills.Skill, dependencies?: string[], callback: fun(ok: boolean, output: string))
+
+---@class CodeCompanion.AgentSkills.InterpreterEntry
+---@field handler CodeCompanion.AgentSkills.InterpreterHandler
+---@field enabled boolean? nil=unchecked, true=available, false=unavailable
+
+---@type table<string, CodeCompanion.AgentSkills.InterpreterEntry>
+local handlers = {}
+
+---@param name string
+---@param handler CodeCompanion.AgentSkills.InterpreterHandler
+local function register(name, handler)
+  handlers[name] = { handler = handler }
+end
+
+---@param opts table<string, table> interpreter config, e.g. { python3 = { ... } }
+function M.setup(opts)
+  local Python3Interpreter = require("codecompanion._extensions.agentskills.interpreter.python3")
+  local SimpleInterpreter = require("codecompanion._extensions.agentskills.interpreter.simple")
+  register("python3", Python3Interpreter.new(opts and opts.python3 or {}))
+  register("node", SimpleInterpreter.new("node"))
+  register("bash", SimpleInterpreter.new("bash"))
+end
+
+---@return table<string, CodeCompanion.AgentSkills.InterpreterHandler>
+function M.get_enabled_interpreters()
+  local result = {}
+  for name, entry in pairs(handlers) do
+    if entry.enabled == nil then
+      entry.enabled = entry.handler:check_available()
+      log:info(
+        entry.enabled and "Interpreter '%s' is enabled"
+          or "Interpreter '%s' is disabled (not available)",
+        name
+      )
+    end
+    if entry.enabled then
+      result[name] = entry.handler
+    end
+  end
+  return result
+end
+
+---@param interpreter string
+---@param skill CodeCompanion.AgentSkills.Skill
+---@param script_path string
+---@param args string[]
+---@param dependencies? string[]
+---@param callback fun(ok: boolean, output: string)
+function M.run(interpreter, skill, script_path, args, dependencies, callback)
+  local entry = handlers[interpreter]
+  if not entry then
+    callback(false, string.format("Interpreter '%s' is not registered", interpreter))
+    return
+  end
+
+  if entry.enabled == nil then
+    entry.enabled = entry.handler:check_available()
+  end
+
+  if not entry.enabled then
+    callback(
+      false,
+      string.format("Interpreter '%s' is not available in current environment", interpreter)
+    )
+    return
+  end
+
+  entry.handler:run(script_path, args, skill, dependencies, callback)
+end
+
+return M

--- a/lua/codecompanion/_extensions/agentskills/interpreter/python3.lua
+++ b/lua/codecompanion/_extensions/agentskills/interpreter/python3.lua
@@ -1,0 +1,167 @@
+local log = require("codecompanion.utils.log")
+
+---@class CodeCompanion.AgentSkills.Python3InterpreterConfig
+---@field prefer_uv boolean prefer uv over pip (default true)
+---@field python_cmd string Python command name (default "python3")
+---@field default_venv_path string Default virtual environment path
+
+---@class CodeCompanion.AgentSkills.Python3Interpreter : CodeCompanion.AgentSkills.InterpreterHandler
+---@field support_dependencies boolean
+---@field config CodeCompanion.AgentSkills.Python3InterpreterConfig
+local Python3Interpreter = {}
+Python3Interpreter.__index = Python3Interpreter
+
+---@param opts? CodeCompanion.AgentSkills.Python3InterpreterConfig
+---@return CodeCompanion.AgentSkills.Python3Interpreter
+function Python3Interpreter.new(opts)
+  local default_venv =
+    vim.fs.joinpath(vim.fn.stdpath("cache"), "codecompanion_agentskills", "python_venv")
+  return setmetatable({
+    support_dependencies = true,
+    config = vim.tbl_deep_extend("force", {
+      prefer_uv = true,
+      python_cmd = "python3",
+      default_venv_path = default_venv,
+    }, opts or {}),
+  }, Python3Interpreter)
+end
+
+local function is_cmd_available(cmd)
+  return vim.fn.executable(cmd) == 1
+end
+
+function Python3Interpreter:check_available()
+  return is_cmd_available("uv") or is_cmd_available(self.config.python_cmd)
+end
+
+local function get_venv_path(skill, config)
+  if skill.meta.metadata and skill.meta.metadata.codecompanion_py_venv_path then
+    return skill.meta.metadata.codecompanion_py_venv_path
+  end
+  return config.default_venv_path
+end
+
+local function should_use_uv(config)
+  return config.prefer_uv and is_cmd_available("uv")
+end
+
+local function run_cmd(cmd, success_msg, error_msg, callback)
+  log:info("Running command: %s", cmd)
+  vim.system(
+    cmd,
+    { stdout = true, stderr = true },
+    vim.schedule_wrap(function(out)
+      if out.code == 0 then
+        log:info(success_msg)
+        callback(true)
+      else
+        local msg = string.format(error_msg, out.stderr or "unknown error")
+        log:error(msg)
+        callback(false, msg)
+      end
+    end)
+  )
+end
+
+local function ensure_venv(venv_path, config, callback)
+  local python_path = vim.fs.joinpath(venv_path, "bin", "python")
+  if vim.uv.fs_stat(python_path) then
+    callback(true)
+    return
+  end
+
+  local cmd, success_msg, error_msg
+  if should_use_uv(config) then
+    cmd = { "uv", "venv", venv_path }
+    success_msg = string.format("Python virtual environment created with uv at %s", venv_path)
+    error_msg = "Failed to create Python virtual environment with uv: %s"
+  else
+    if not is_cmd_available(config.python_cmd) then
+      callback(false, "Neither 'uv' nor 'python3' is available")
+      return
+    end
+    cmd = { config.python_cmd, "-m", "venv", venv_path }
+    success_msg = string.format("Python virtual environment created with python3 at %s", venv_path)
+    error_msg = "Failed to create Python virtual environment with python3: %s"
+  end
+
+  run_cmd(cmd, success_msg, error_msg, callback)
+end
+
+local function install_dependencies(venv_path, dependencies, config, callback)
+  if not dependencies or #dependencies == 0 then
+    callback(true)
+    return
+  end
+
+  local python_path = vim.fs.joinpath(venv_path, "bin", "python")
+  local cmd, success_msg, error_msg
+  if should_use_uv(config) then
+    cmd = { "uv", "pip", "install", "--python", python_path }
+    success_msg = "Python dependencies installed with uv: " .. table.concat(dependencies, ", ")
+    error_msg = "Failed to install Python dependencies with uv: %s"
+  else
+    cmd = { python_path, "-m", "pip", "install" }
+    success_msg = "Python dependencies installed with pip: " .. table.concat(dependencies, ", ")
+    error_msg = "Failed to install Python dependencies with pip: %s"
+  end
+
+  vim.list_extend(cmd, dependencies)
+  run_cmd(cmd, success_msg, error_msg, callback)
+end
+
+---@param script_path string
+---@param args string[]
+---@param skill CodeCompanion.AgentSkills.Skill
+---@param dependencies? string[]
+---@param callback fun(ok: boolean, output: string)
+function Python3Interpreter:run(script_path, args, skill, dependencies, callback)
+  local config = self.config
+  local venv_path = get_venv_path(skill, config)
+
+  ensure_venv(venv_path, config, function(ok, err)
+    if not ok then
+      callback(false, err or "Failed to ensure Python virtual environment exists")
+      return
+    end
+
+    install_dependencies(venv_path, dependencies, config, function(ok, err)
+      if not ok then
+        callback(false, err or "Failed to install Python dependencies")
+        return
+      end
+
+      local python_path = vim.fs.joinpath(venv_path, "bin", "python")
+      local cmd = { python_path, script_path }
+      vim.list_extend(cmd, args)
+
+      log:info("Running Python script: %s", cmd)
+      local env = {
+        PYTHONPATH = string.format("%s:%s", skill.path, vim.env.PYTHONPATH or ""),
+      }
+      vim.system(cmd, { env = env, stdout = true, stderr = true }, function(out)
+        log:info("Python script exited with code %d", out.code)
+        if out.code == 0 then
+          callback(true, out.stdout)
+        else
+          local msg = out.signal
+              and out.signal ~= 0
+              and string.format("Script terminated with signal %d", out.signal)
+            or string.format("Script exited with code %d", out.code)
+          local output = { msg }
+          if out.stdout and out.stdout ~= "" then
+            table.insert(output, "Standard Output:")
+            table.insert(output, out.stdout)
+          end
+          if out.stderr and out.stderr ~= "" then
+            table.insert(output, "Standard Error:")
+            table.insert(output, out.stderr)
+          end
+          callback(false, table.concat(output, "\n"))
+        end
+      end)
+    end)
+  end)
+end
+
+return Python3Interpreter

--- a/lua/codecompanion/_extensions/agentskills/interpreter/simple.lua
+++ b/lua/codecompanion/_extensions/agentskills/interpreter/simple.lua
@@ -1,0 +1,57 @@
+local log = require("codecompanion.utils.log")
+
+---@class CodeCompanion.AgentSkills.SimpleInterpreter : CodeCompanion.AgentSkills.InterpreterHandler
+---@field cmd string interpreter command
+---@field support_dependencies boolean
+local SimpleInterpreter = {}
+SimpleInterpreter.__index = SimpleInterpreter
+
+---@param cmd string
+---@return CodeCompanion.AgentSkills.SimpleInterpreter
+function SimpleInterpreter.new(cmd)
+  return setmetatable({ cmd = cmd, support_dependencies = false }, SimpleInterpreter)
+end
+
+function SimpleInterpreter:check_available()
+  return vim.fn.executable(self.cmd) == 1
+end
+
+---@param script_path string
+---@param args string[]
+---@param _skill CodeCompanion.AgentSkills.Skill
+---@param dependencies? string[]
+---@param callback fun(ok: boolean, output: string)
+function SimpleInterpreter:run(script_path, args, _skill, dependencies, callback)
+  if dependencies and #dependencies > 0 then
+    callback(false, string.format("Dependencies are not supported for '%s' interpreter.", self.cmd))
+    return
+  end
+
+  local full_cmd = { self.cmd, script_path }
+  vim.list_extend(full_cmd, args)
+
+  log:info("Running script with interpreter '%s': %s", self.cmd, full_cmd)
+  vim.system(full_cmd, { stdout = true, stderr = true }, function(out)
+    log:info("Script exited with code %d: %s", out.code, full_cmd)
+    if out.code == 0 then
+      callback(true, out.stdout)
+    else
+      local msg = out.signal
+          and out.signal ~= 0
+          and string.format("Script terminated with signal %d", out.signal)
+        or string.format("Script exited with code %d", out.code)
+      local output = { msg }
+      if out.stdout and out.stdout ~= "" then
+        table.insert(output, "Standard Output:")
+        table.insert(output, out.stdout)
+      end
+      if out.stderr and out.stderr ~= "" then
+        table.insert(output, "Standard Error:")
+        table.insert(output, out.stderr)
+      end
+      callback(false, table.concat(output, "\n"))
+    end
+  end)
+end
+
+return SimpleInterpreter

--- a/lua/codecompanion/_extensions/agentskills/skill.lua
+++ b/lua/codecompanion/_extensions/agentskills/skill.lua
@@ -1,6 +1,14 @@
 local log = require("codecompanion.utils.log")
 local yaml = require("codecompanion._extensions.agentskills.3rd.yaml")
 
+---@class CodeCompanion.AgentSkills.SkillOpts
+---@field scripts_require_approval? boolean Whether to require user approval before running scripts (default: true)
+
+---@type CodeCompanion.AgentSkills.SkillOpts
+local DEFAULT_SKILL_OPTS = {
+  scripts_require_approval = true,
+}
+
 local MD_YAML_FRONTMATTER_QUERY =
   vim.treesitter.query.parse("markdown", "(document (minus_metadata) @yaml_frontmatter)")
 
@@ -29,6 +37,7 @@ end
 ---@class CodeCompanion.AgentSkills.Skill
 ---@field path string
 ---@field meta table<string, any>
+---@field opts CodeCompanion.AgentSkills.SkillOpts Per-skill options
 local Skill = {
   SKILL_DIR_PLACEHOLDER = "${SKILL_DIR}",
 }
@@ -41,9 +50,17 @@ function Skill.load(path)
   if meta == nil then
     error("Failed to parse SKILL.md frontmatter at " .. path)
   end
+
+  -- Get skill options by skill name from global config
+  local skill_name = vim.trim(meta.name)
+  local Extension = require("codecompanion._extensions.agentskills")
+  local global_opts = Extension.get_opts()
+  local skill_opts = global_opts.skill_opts and global_opts.skill_opts[skill_name]
+
   return setmetatable({
     path = path,
     meta = meta,
+    opts = vim.tbl_deep_extend("force", DEFAULT_SKILL_OPTS, skill_opts or {}),
   }, Skill)
 end
 

--- a/lua/codecompanion/_extensions/agentskills/skill.lua
+++ b/lua/codecompanion/_extensions/agentskills/skill.lua
@@ -78,42 +78,28 @@ end
 
 ---@param script string
 ---@param args string[]
+---@param interpreter string
+---@param dependencies? string[]
 ---@param callback fun(ok: boolean, output_or_error: string)
-function Skill:run_script(script, args, callback)
-  local cmd = { self:_normalize_path_in_skill(script) }
+function Skill:run_script(script, args, interpreter, dependencies, callback)
+  local script_path = self:_normalize_path_in_skill(script)
+
+  -- Replace SKILL_DIR placeholder in arguments
   local placeholder_pattern = vim.pesc(self.SKILL_DIR_PLACEHOLDER)
+  local processed_args = {}
   for _, arg in ipairs(args or {}) do
-    arg = string.gsub(arg, placeholder_pattern, self.path)
-    table.insert(cmd, arg)
+    local new_arg = string.gsub(arg, placeholder_pattern, self.path)
+    table.insert(processed_args, new_arg)
   end
-  log:info("Running skill script: %s", cmd)
-  vim.system(cmd, {
-    stdout = true,
-    stderr = true,
-  }, function(out)
-    log:info("Skill script exited with code %d: %s", out.code, cmd)
-    callback = vim.schedule_wrap(callback)
-    if out.code == 0 then
-      callback(true, out.stdout)
-    else
-      local msg
-      if out.signal and out.signal ~= 0 then
-        msg = string.format("Script terminated with signal %d", out.signal)
-      else
-        msg = string.format("Script exited with code %d", out.code)
-      end
-      local output = { msg }
-      if out.stdout and out.stdout ~= "" then
-        table.insert(output, "Standard Output:")
-        table.insert(output, out.stdout)
-      end
-      if out.stderr and out.stderr ~= "" then
-        table.insert(output, "Standard Error:")
-        table.insert(output, out.stderr)
-      end
-      callback(false, table.concat(output, "\n"))
-    end
-  end)
+
+  require("codecompanion._extensions.agentskills.interpreter").run(
+    interpreter,
+    self,
+    script_path,
+    processed_args,
+    dependencies,
+    callback
+  )
 end
 
 return Skill

--- a/lua/codecompanion/_extensions/agentskills/skill.lua
+++ b/lua/codecompanion/_extensions/agentskills/skill.lua
@@ -76,12 +76,12 @@ function Skill:read_file(path_in_skill)
   return vim.fn.readblob(self:_normalize_path_in_skill(path_in_skill))
 end
 
----@param script string
----@param args string[]
 ---@param interpreter string
+---@param script string
+---@param args? string[]
 ---@param dependencies? string[]
 ---@param callback fun(ok: boolean, output_or_error: string)
-function Skill:run_script(script, args, interpreter, dependencies, callback)
+function Skill:run_script(interpreter, script, args, dependencies, callback)
   local script_path = self:_normalize_path_in_skill(script)
 
   -- Replace SKILL_DIR placeholder in arguments

--- a/lua/codecompanion/_extensions/agentskills/tools.lua
+++ b/lua/codecompanion/_extensions/agentskills/tools.lua
@@ -20,8 +20,8 @@ You are equipped with a **Progressive Disclosure Agent Skills System**. This all
 2. **Activate**: Call `activate_skill` with the skill name. This injects the skill's specific instructions (SOPs) into your context.
 3. **Execute**: Strictly follow the new instructions provided by the skill.
 4. **Resource Access**: If the skill instructions reference files (docs, templates) or scripts:
-   - Use `load_skill_file` to read text content.
-   - Use `run_skill_script` to execute executable scripts.
+   - Use `load_skill_file` to read files that are **explicitly referenced in the activated skill's documentation**. Never use it for files not mentioned in the skill.
+   - Use `run_skill_script` to execute scripts that are **explicitly listed in the activated skill's documentation**. Never use it for scripts not mentioned in the skill.
 
 ## ⚠️ CRITICAL RULES
 1. **VIRTUAL FILESYSTEM**: Files mentioned within a skill (e.g., `assets/template.md`, `scripts/build.sh`) exist in a **virtual skill directory**, NOT the user's physical workspace.
@@ -94,7 +94,7 @@ function Tools.load_skill_file()
       type = "function",
       ["function"] = {
         name = "load_skill_file",
-        description = "Load a file provided by a skill.",
+        description = "Load a file that is pre-packaged inside an activated skill's directory.\n\n**PREREQUISITE (must satisfy ALL before calling)**:\n1. You have already called `activate_skill` for the target skill.\n2. The skill's documentation **explicitly references** the file path you intend to load.\n3. The `file_path` is copied **verbatim** from the skill's documentation — do NOT construct or guess paths.\n\nIf no file is referenced in the skill documentation, do NOT call this tool. For files in the user's workspace, use standard file reading tools instead. To execute skill scripts, use `run_skill_script`.",
         parameters = {
           type = "object",
           properties = {
@@ -171,7 +171,17 @@ function Tools.run_skill_script()
       ["function"] = {
         name = "run_skill_script",
         description = string.format(
-          [[Run a script provided by a skill. The script will be executed in user's current working directory. Use placeholder '%s' in arguments to refer to the skill directory.
+          [[Run a script that is **pre-packaged inside an activated skill's directory**.
+
+**PREREQUISITE (must satisfy ALL before calling)**:
+1. You have already called `activate_skill` for the target skill.
+2. The skill's documentation **explicitly lists** the script path you intend to run.
+3. The `script_path` is copied **verbatim** from the skill's documentation — do NOT construct or guess paths.
+
+If no script is listed in the skill documentation, do NOT call this tool.
+If you need to run a general command unrelated to any skill, this tool CANNOT help — inform the user instead.
+
+The script runs in the user's current working directory. Use placeholder '%s' in arguments to refer to the skill directory.
 
 Supported interpreters:
 %s
@@ -218,6 +228,16 @@ Note: Only interpreters that support dependencies can use the 'dependencies' par
     },
     cmds = {
       function(self, args, opts)
+        if args.skill_name == nil then
+          return { status = "error", data = "Missing required parameter: skill_name" }
+        end
+        if args.script_path == nil then
+          return { status = "error", data = "Missing required parameter: script_path" }
+        end
+        if args.interpreter == nil then
+          return { status = "error", data = "Missing required parameter: interpreter" }
+        end
+
         local AS = require("codecompanion._extensions.agentskills")
         local skill = AS.get_skill(args.skill_name)
         if not skill then
@@ -244,7 +264,11 @@ Note: Only interpreters that support dependencies can use the 'dependencies' par
           self.args.interpreter,
           self.args.script_path,
         }
-        for _, arg in ipairs(self.args.args or {}) do
+        local args = self.args.args
+        if args == vim.NIL or args == nil then
+          args = {}
+        end
+        for _, arg in ipairs(args) do
           table.insert(argv, vim.fn.escape(arg, " "))
         end
 

--- a/lua/codecompanion/_extensions/agentskills/tools.lua
+++ b/lua/codecompanion/_extensions/agentskills/tools.lua
@@ -244,9 +244,9 @@ Note: Only interpreters that support dependencies can use the 'dependencies' par
           return { status = "error", data = "Skill not found: " .. args.skill_name }
         end
         skill:run_script(
-          args.script_path,
-          args.args or {},
           args.interpreter,
+          args.script_path,
+          args.args ~= vim.NIL and args.args or nil,
           args.dependencies ~= vim.NIL and args.dependencies or nil,
           vim.schedule_wrap(function(ok, output)
             if ok then
@@ -258,19 +258,35 @@ Note: Only interpreters that support dependencies can use the 'dependencies' par
         )
       end,
     },
+    handlers = {
+      setup = function(self, meta)
+        -- Smart argument escaping logic (for display only)
+        local args = self.args.args
+        if args == vim.NIL or args == nil then
+          self.escaped_args = {}
+          return
+        end
+
+        local escaped = {}
+        for _, arg in ipairs(args) do
+          if string.match(arg, "^[%w%.%-%_/:]+$") then
+            table.insert(escaped, arg)
+          else
+            table.insert(escaped, vim.fn.shellescape(arg))
+          end
+        end
+
+        self.escaped_args = escaped
+      end,
+    },
+
     output = {
       prompt = function(self)
         local argv = {
           self.args.interpreter,
           self.args.script_path,
+          unpack(self.escaped_args),
         }
-        local args = self.args.args
-        if args == vim.NIL or args == nil then
-          args = {}
-        end
-        for _, arg in ipairs(args) do
-          table.insert(argv, vim.fn.escape(arg, " "))
-        end
 
         local msg = {
           string.format("Confirm to run script from skill '%s'?", self.args.skill_name),
@@ -287,21 +303,14 @@ Note: Only interpreters that support dependencies can use the 'dependencies' par
 
       success = function(self, output, meta)
         local output = output[#output]
-        local parts = { self.args.interpreter, self.args.script_path }
-        for _, arg in ipairs(self.args.args or {}) do
-          table.insert(parts, vim.fn.escape(arg, " "))
-        end
-        local for_user =
-          string.format("Run skill script successfully: %s", table.concat(parts, " "))
+        local argv = { self.args.interpreter, self.args.script_path, unpack(self.escaped_args) }
+        local for_user = string.format("Run skill script successfully: %s", table.concat(argv, " "))
         meta.tools.chat:add_tool_output(self, output, for_user)
       end,
 
       error = function(self, output, meta)
         local error_msg = output[#output]
-        local parts = { self.args.interpreter, self.args.script_path }
-        for _, arg in ipairs(self.args.args or {}) do
-          table.insert(parts, vim.fn.escape(arg, " "))
-        end
+        local parts = { self.args.interpreter, self.args.script_path, unpack(self.escaped_args) }
         local for_user = string.format(
           "Failed to run skill script: %s. Error: %s",
           table.concat(parts, " "),

--- a/lua/codecompanion/_extensions/agentskills/tools.lua
+++ b/lua/codecompanion/_extensions/agentskills/tools.lua
@@ -150,6 +150,20 @@ function Tools.load_skill_file()
 end
 
 function Tools.run_skill_script()
+  local interpreters =
+    require("codecompanion._extensions.agentskills.interpreter").get_enabled_interpreters()
+  local interpreter_lines = {}
+  local available_names = {}
+  for name, handler in pairs(interpreters) do
+    table.insert(available_names, name)
+    local deps_note = handler.support_dependencies and " (supports dependencies)" or ""
+    table.insert(interpreter_lines, string.format("- %s%s", name, deps_note))
+  end
+  table.sort(available_names)
+  table.sort(interpreter_lines)
+
+  local interpreter_desc = table.concat(interpreter_lines, "\n")
+
   return {
     name = "run_skill_script",
     schema = {
@@ -157,8 +171,14 @@ function Tools.run_skill_script()
       ["function"] = {
         name = "run_skill_script",
         description = string.format(
-          [[Run a script provided by a skill. The script will be executed in user's current working directory. Use placeholder '%s' in arguments to refer to the skill directory.]],
-          Skill.SKILL_DIR_PLACEHOLDER
+          [[Run a script provided by a skill. The script will be executed in user's current working directory. Use placeholder '%s' in arguments to refer to the skill directory.
+
+Supported interpreters:
+%s
+
+Note: Only interpreters that support dependencies can use the 'dependencies' parameter.]],
+          Skill.SKILL_DIR_PLACEHOLDER,
+          interpreter_desc
         ),
         parameters = {
           type = "object",
@@ -173,17 +193,25 @@ function Tools.run_skill_script()
             },
             args = {
               type = "array",
-              items = {
-                type = "string",
-              },
+              items = { type = "string" },
               description = string.format(
                 [[Argument array to pass to the script. Placeholder '%s' will be replaced with the skill directory path. E.g: ["--template", "%s/assets/template.html"].]],
                 Skill.SKILL_DIR_PLACEHOLDER,
                 Skill.SKILL_DIR_PLACEHOLDER
               ),
             },
+            interpreter = {
+              type = "string",
+              enum = available_names,
+              description = "The interpreter to use for running the script.",
+            },
+            dependencies = {
+              type = "array",
+              items = { type = "string" },
+              description = [[List of runtime dependencies. Only supported by interpreters that support dependencies. E.g: ["requests", "numpy>=1.20"].]],
+            },
           },
-          required = { "skill_name", "script_path" },
+          required = { "skill_name", "script_path", "interpreter" },
         },
         strict = true,
       },
@@ -195,39 +223,64 @@ function Tools.run_skill_script()
         if not skill then
           return { status = "error", data = "Skill not found: " .. args.skill_name }
         end
-        skill:run_script(args.script_path, args.args or {}, function(ok, output)
-          if ok then
-            opts.output_cb({ status = "success", data = output })
-          else
-            opts.output_cb({ status = "error", data = output })
-          end
-        end)
+        skill:run_script(
+          args.script_path,
+          args.args or {},
+          args.interpreter,
+          args.dependencies ~= vim.NIL and args.dependencies or nil,
+          vim.schedule_wrap(function(ok, output)
+            if ok then
+              opts.output_cb({ status = "success", data = output })
+            else
+              opts.output_cb({ status = "error", data = output })
+            end
+          end)
+        )
       end,
     },
     output = {
       prompt = function(self)
-        return string.format(
-          "Confirm to run script from skill '%s' ?\n%s %s",
-          self.args.skill_name,
+        local argv = {
+          self.args.interpreter,
           self.args.script_path,
-          table.concat(self.args.args or {}, " ")
-        )
+        }
+        for _, arg in ipairs(self.args.args or {}) do
+          table.insert(argv, vim.fn.escape(arg, " "))
+        end
+
+        local msg = {
+          string.format("Confirm to run script from skill '%s'?", self.args.skill_name),
+          "Command:\n    " .. table.concat(argv, " "),
+        }
+
+        local deps = self.args.dependencies ~= vim.NIL and self.args.dependencies or nil
+        if deps and #deps > 0 then
+          table.insert(msg, "Dependencies:\n    " .. table.concat(deps, ", "))
+        end
+
+        return table.concat(msg, "\n")
       end,
+
       success = function(self, output, meta)
         local output = output[#output]
-        local for_user = string.format(
-          "Run skill script successfully: %s %s",
-          self.args.script_path,
-          table.concat(self.args.args or {}, " ")
-        )
+        local parts = { self.args.interpreter, self.args.script_path }
+        for _, arg in ipairs(self.args.args or {}) do
+          table.insert(parts, vim.fn.escape(arg, " "))
+        end
+        local for_user =
+          string.format("Run skill script successfully: %s", table.concat(parts, " "))
         meta.tools.chat:add_tool_output(self, output, for_user)
       end,
+
       error = function(self, output, meta)
         local error_msg = output[#output]
+        local parts = { self.args.interpreter, self.args.script_path }
+        for _, arg in ipairs(self.args.args or {}) do
+          table.insert(parts, vim.fn.escape(arg, " "))
+        end
         local for_user = string.format(
-          "Failed to run skill script: %s %s. Error: %s",
-          self.args.script_path,
-          table.concat(self.args.args or {}, " "),
+          "Failed to run skill script: %s. Error: %s",
+          table.concat(parts, " "),
           error_msg
         )
         meta.tools.chat:add_tool_output(self, error_msg, for_user)

--- a/lua/codecompanion/_extensions/agentskills/tools.lua
+++ b/lua/codecompanion/_extensions/agentskills/tools.lua
@@ -260,6 +260,15 @@ Note: Only interpreters that support dependencies can use the 'dependencies' par
     },
     handlers = {
       setup = function(self, meta)
+        -- Dynamic approval settings based on scripts_require_approval
+        local AS = require("codecompanion._extensions.agentskills")
+        local skill = AS.get_skill(self.args.skill_name)
+        if skill and skill.opts and skill.opts.scripts_require_approval == false then
+          self.opts.require_approval_before = false
+        else
+          self.opts.require_approval_before = true
+        end
+
         -- Smart argument escaping logic (for display only)
         local args = self.args.args
         if args == vim.NIL or args == nil then

--- a/stylua.toml
+++ b/stylua.toml
@@ -1,3 +1,4 @@
+syntax = "LuaJIT"
 indent_width = 2
 indent_type = "Spaces"
 call_parentheses = "Input"


### PR DESCRIPTION
## Background
The Agent Skills spec says almost nothing useful about how scripts should be executed. Many existing skills assume their scripts can have dependencies (in-skill references and third party libs), and many others don't set shebang and executable bit in their scripts.

## Design
Implement script execution wrappers (`InterpreterHandler`s) to support dependencies (to some extent). Python scripts are executed in a reusable venv which allow installing dependencies. LLMs are requested to select which interpreter to use.

## Changes
- Implement Python, Bash, Node.js interpreter handlers
- Add Python venv management with uv/pip support
- Support script dependencies and virtual environment isolation
- Add built-in demo-skill showcasing feature usage
- Enhance run_skill_script tool with interpreter selection