### PR TITLE
fix: make run_skill_script schema Azure-compatible

### DIFF
--- a/lua/codecompanion/_extensions/agentskills/tools.lua
+++ b/lua/codecompanion/_extensions/agentskills/tools.lua
@@ -241,7 +241,7 @@ Note: Only interpreters that support dependencies can use the 'dependencies' par
               description = [[List of runtime dependencies. Only supported by interpreters that support dependencies. E.g: ["requests", "numpy>=1.20"].]],
             },
           },
-          required = { "skill_name", "script_path", "interpreter" },
+          required = { "skill_name", "script_path", "args", "interpreter", "dependencies" },
         },
         strict = true,
       },


### PR DESCRIPTION
Include args and dependencies in required fields for run_skill_script tool schema to satisfy Azure/OpenAI-compatible validators used by OpenRouter.

Also normalize optional array parameters to empty arrays instead of nil values for improved compatibility.

close #10 